### PR TITLE
Fix duplicated tensors in a 'gather_none' scenario

### DIFF
--- a/src/accmt/dist_utils.py
+++ b/src/accmt/dist_utils.py
@@ -72,7 +72,7 @@ def gather_object(obj: Any, num_processes: int = None) -> list[Any]:
     return collected
 
 
-def gather_into_single_process(tensor: Optional[torch.Tensor], dst: int = 0) -> torch.Tensor:
+def gather_into_single_process(tensor: Optional[torch.Tensor], dst: int = 0, remainder: int = 0) -> torch.Tensor:
     if WORLD_SIZE == 1:
         return tensor
 
@@ -86,6 +86,8 @@ def gather_into_single_process(tensor: Optional[torch.Tensor], dst: int = 0) -> 
     output = None
     if rank == dst:
         rank_device = f"cuda:{dst}"
+        if remainder > 0:
+            collected = collected[:remainder]
         tensors = [tensor.to(rank_device) for tensor in collected if tensor is not None]
         if len(tensors) > 0:
             output = torch.cat(tensors)


### PR DESCRIPTION
This PR fixes duplicated tensors in scenarios where **None** tensors are gathered.

We introduce the following:
- 'gather_none' argument in Trainer, to specify if **None** objects are being gathered in evaluation (defaults to False).
- When 'gather_none' is set to True, we use 'gather_into_single_process' with an extra argument 'remainder', which takes Accelerate's 'gradient_state.remainder' (same remainder used inside 'gather_for_metrics'). If remainder > 0, we drop all the remainder tensors in the collected list in process rank 0 (main process).
- When 'gather_none' is set to False (default), we simply use 'gather_for_metrics' which automatically drops duplicated tensors.

**NOTE**: This might need some testing before merging.