### PR TITLE
Modified metric system

### DIFF
--- a/src/accmt/trainer.py
+++ b/src/accmt/trainer.py
@@ -135,6 +135,7 @@ class Trainer:
         cleanup_cache_every_n_steps: Optional[int] = None,
         callback: Optional[Callback] = None,
         gather_none: bool = False,
+        additional_tracker_config: Optional[dict[str, Any]] = None,
         **kwargs: Optional[Any],
     ):
         """
@@ -271,6 +272,8 @@ class Trainer:
                 In evaluation, allow `None` objects across different processes to be collected. This incurs in
                 GPU -> CPU transfer. By default (`False`), tensors are gathered considering that there are no `None` or any
                 object types, only `Tensor` objects.
+            additional_tracker_config (`dict`, *optional*, defaults to `None`):
+                Additional configuration specification for tracker (e.g. hyper-parameters).
             kwargs (`Any`, *optional*):
                 Extra arguments for specific `init` function in Tracker, e.g. `run_name`, `tags`, etc.
         """
@@ -371,6 +374,7 @@ class Trainer:
         self.cleanup_cache_every_n_steps = cleanup_cache_every_n_steps
         self.callback = callback if callback is not None else Callback()
         self.gather_none = gather_none
+        self.additional_tracker_config = additional_tracker_config if additional_tracker_config is not None else {}
         self.init_kwargs = kwargs
 
         self.accelerator.project_configuration = ProjectConfiguration(
@@ -611,7 +615,8 @@ class Trainer:
                 config["num_processes"] = self.accelerator.num_processes
 
                 if DEBUG_MODE < 1:
-                    self.accelerator.init_trackers(track_name, config=config, init_kwargs=init_kwargs)
+                    tracker_config = config | self.additional_tracker_config
+                    self.accelerator.init_trackers(track_name, config=tracker_config, init_kwargs=init_kwargs)
 
             if self.resume:
                 self.callback.on_resume()

--- a/src/tests/dummy_metrics.py
+++ b/src/tests/dummy_metrics.py
@@ -16,7 +16,8 @@ from src.accmt.metrics import Metric
 
 
 class Accuracy(Metric):
-    def compute(self, predictions, references):
+    def compute(self, predictions, references, extra_references):
         print(predictions.shape)
         print(references.shape)
+        print(extra_references.shape)
         return {"accuracy": 0.85, "test_metric": 0.5}

--- a/src/tests/train.py
+++ b/src/tests/train.py
@@ -48,8 +48,13 @@ class DummyModule(AcceleratorModule):
 
         predictions = torch.argmax(x, dim=1)
         references = torch.argmax(y, dim=1)
+        extra_references = references.clone()
 
-        return {"loss": loss, "accuracy": (predictions, references), "my_own_metric": (predictions, references)}
+        return {
+            "loss": loss,
+            "accuracy": (predictions, references, extra_references),
+            "my_own_metric": (predictions, references),
+        }
 
 
 module = DummyModule()


### PR DESCRIPTION
This PR modifies the metric system to add a custom number of arguments for the **compute** function. Previous behavior only had the arguments 'predictions' and 'references'. This change will make users able to keep track of other arguments that are outside of the predictions-references domain.