### PR TITLE
Added 'patience' argument to Trainer

### DIFF
--- a/src/tests/train.py
+++ b/src/tests/train.py
@@ -95,6 +95,7 @@ trainer = Trainer(
     metrics=metrics,
     callback=DummyCallback(),
     report_train_loss_per_epoch=True,
+    patience=2,
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added 'patience' argument to Trainer to check if model savings were not improving for an amount of model savings. If its value is greather than 0, patience will be implemented. If its value is 0, it will throw an error. If its value is less than 0, no patience will be implemented.