### PR TITLE
Multiple checkpointing

### DIFF
--- a/src/accmt/monitor.py
+++ b/src/accmt/monitor.py
@@ -47,7 +47,9 @@ class Monitor:
         gpu_utilization (`bool`, *optional*, defaults to `False`):
             Monitor GPU utilization in GB. It only reports GPU from main process (for now).
         cpu_utilization (`bool`, *optional*, defaults to `False`):
-            Monitor CPU utilization in GB. It only reports CPU from main process (for now)
+            Monitor CPU utilization in GB. It only reports CPU from main process (for now).
+        checkpoint (`bool`, *optional*, defaults to `False`):
+            Monitor checkpoint.
     """
 
     def __init__(
@@ -60,6 +62,7 @@ class Monitor:
         grad_norm: bool = False,
         gpu_utilization: bool = False,
         cpu_utilization: bool = False,
+        checkpoint: bool = False,
     ):
         self.learning_rate = learning_rate
         self.epoch = epoch
@@ -69,6 +72,7 @@ class Monitor:
         self.grad_norm = grad_norm
         self.gpu_utilization = gpu_utilization
         self.cpu_utilization = cpu_utilization
+        self.checkpoint = checkpoint
         self.accelerator: Accelerator = None
         self.tracker: BaseTracker = None
         self.train_loss_name: str = None
@@ -154,6 +158,10 @@ class Monitor:
             process = psutil.Process(os.getpid())
             cpu_mem = process.memory_info().rss / (1024**3)
             self.log("CPU_PROCESS_0", cpu_mem, run_id=run_id)
+
+    def log_checkpoint(self, run_id: Optional[str] = None):
+        if self._tracking and self.checkpoint:
+            self.log("checkpoint", self.state.num_checkpoints_made, run_id=run_id)
 
     def log_grad_norm(self, value: Union[int, float, torch.Tensor], run_id: Optional[str] = None):
         if self._tracking and self.grad_norm:

--- a/src/accmt/states.py
+++ b/src/accmt/states.py
@@ -58,6 +58,8 @@ class TrainingState:
             Best validation loss achieved.
         finished (`bool`, *optional*, defaults to `False`):
             Flag to identify if the process has already finished.
+        num_checkpoints_made (`int`, *optional*, defaults to `0`):
+            Number of checkpoints made.
     """
 
     global_step: int = field(default=0)
@@ -74,6 +76,7 @@ class TrainingState:
     patience_left: dict[str, int] = field(default_factory=dict)
     best_train_loss: float = field(default=float("inf"))
     finished: bool = field(default=False)
+    num_checkpoints_made: int = field(default=0)
 
     def update(
         self,
@@ -91,6 +94,7 @@ class TrainingState:
         patience_left: Optional[dict[str, int]] = None,
         best_train_loss: Optional[float] = None,
         finished: Optional[bool] = None,
+        num_checkpoints_made: Optional[int] = None,
         **kwargs: Any,
     ):
         # ignore positional arguments for safety
@@ -108,6 +112,7 @@ class TrainingState:
             "patience_left": patience_left,
             "best_train_loss": best_train_loss,
             "finished": finished,
+            "num_checkpoints_made": num_checkpoints_made,
         }
 
         for key, value in updates.items():

--- a/src/accmt/trainer.py
+++ b/src/accmt/trainer.py
@@ -15,6 +15,7 @@
 import inspect
 import math
 import os
+import shutil
 import signal
 import sys
 import time
@@ -75,6 +76,7 @@ class Trainer:
         track_name: Optional[str] = None,
         enable_checkpointing: bool = True,
         multiple_checkpoints: bool = False,
+        max_checkpoints: Optional[int] = None,
         resume: Optional[Union[bool, int]] = None,
         disable_model_saving: bool = False,
         patience: Optional[Union[int, dict[str, Any]]] = None,
@@ -130,11 +132,14 @@ class Trainer:
                 Enable checkpointing.
             multiple_checkpoints (`bool`, *optional*, defaults to `False`):
                 Enable multiple checkpoints.
+            max_checkpoints (`int`, *optional*, defaults to `None`):
+                Maximum number of checkpoints to keep. If set to `None`, all checkpoints will be kept.
             resume (`bool` or `int`, *optional*, defaults to `None`):
                 Whether to resume from checkpoint. Default option is `None`, which means resuming from checkpoint
                 will be handled automatically, whether the checkpoint directory exists or not.
                 If set to `True`, the latest checkpoint will be loaded.
-                If set to an integer, the checkpoint will be loaded from the given index.
+                If set to an integer, the checkpoint will be loaded from the given index (if `multiple_checkpoints` is `True`).
+                If set to `-1`, the latest checkpoint will be loaded (if `multiple_checkpoints` is `True`).
             disable_model_saving (`bool`, *optional*, defaults to `False`):
                 Disable any model saving registered (by default, `"best_valid_loss"` is registered, or if there are none evaluations to do,
                 default will be `"best_train_loss"`).
@@ -284,12 +289,9 @@ class Trainer:
                 raise ValueError(
                     "Cannot specify a checkpoint index in 'resume' when 'multiple_checkpoints' is disabled."
                 )
-            elif resume <= 0:
-                raise ValueError("Checkpoint index in 'resume' must be greater than 0.")
-            elif resume > len(os.listdir(self.checkpoint_path)):
+            elif resume == 0 or resume < -1:
                 raise ValueError(
-                    "Checkpoint index in 'resume' is greater than the number of checkpoints "
-                    f"({len(os.listdir(self.checkpoint_path))})."
+                    "Checkpoint index in 'resume' must be greater than 0 (or -1 to resume from latest checkpoint)."
                 )
         self.resume = (
             (
@@ -326,6 +328,9 @@ class Trainer:
         self.evaluate_every_n_steps = evaluate_every_n_steps
         self.enable_checkpointing = enable_checkpointing if DEBUG_MODE < 3 else False
         self.multiple_checkpoints = multiple_checkpoints
+        if max_checkpoints is not None and max_checkpoints <= 0:
+            raise ValueError("'max_checkpoints' must be greater than 0 or `None`.")
+        self.max_checkpoints = max_checkpoints
         self.checkpoint_every, self.checkpoint_strat = get_number_and_unit(checkpoint_every)
         self.logging_dir = logging_dir
         self.log_every = log_every
@@ -496,6 +501,8 @@ class Trainer:
 
         if self.resume:
             checkpoint_path = self._get_current_checkpoint_path()
+            if checkpoint_path.endswith("checkpoint_0"):
+                raise FileNotFoundError("Checkpoint directory is empty or not found.")
             training_state_path = os.path.join(checkpoint_path, STATE_FILE)
             loss_tracker_path = os.path.join(checkpoint_path, TRAIN_LOSS_STATE_FILE)
             self.state.load(training_state_path)
@@ -1157,8 +1164,16 @@ class Trainer:
         self.accelerator.wait_for_everyone()
         checkpoint_path = self.checkpoint_path
         if self.multiple_checkpoints:
-            num_checkpoints = len(os.listdir(checkpoint_path)) if os.path.exists(checkpoint_path) else 0
-            new_checkpoint_path = os.path.join(checkpoint_path, f"checkpoint_{num_checkpoints + 1}")
+            if (
+                MASTER_PROCESS
+                and self.max_checkpoints is not None
+                and len(os.listdir(checkpoint_path)) >= self.max_checkpoints
+            ):
+                min_checkpoint = min(os.listdir(checkpoint_path), key=lambda x: int(x.split("_")[-1]))
+                shutil.rmtree(os.path.join(checkpoint_path, min_checkpoint))
+
+            last_checkpoint_num = int(self._get_current_checkpoint_path(ignore_resume_idx=True).split("_")[-1])
+            new_checkpoint_path = os.path.join(checkpoint_path, f"checkpoint_{last_checkpoint_num + 1}")
             if MASTER_PROCESS:
                 os.makedirs(new_checkpoint_path, exist_ok=True)
             checkpoint_path = new_checkpoint_path
@@ -1261,6 +1276,8 @@ class Trainer:
             self.callback.on_resume()
             if os.path.exists(self.checkpoint_path):
                 checkpoint_path = self._get_current_checkpoint_path()
+                if checkpoint_path.endswith("checkpoint_0"):
+                    raise FileNotFoundError("Checkpoint directory is empty or not found.")
                 self.accelerator.load_state(checkpoint_path)
             else:
                 raise FileNotFoundError(f"'{self.checkpoint_path}' was not found.")
@@ -1273,20 +1290,25 @@ class Trainer:
 
         return model, teacher, train_dataloader, val_dataloader, optimizer, scheduler
 
-    def _get_current_checkpoint_path(self):
-        """Get the checkpoint path based on the 'resume' argument or the latest checkpoint."""
+    def _get_current_checkpoint_path(self, ignore_resume_idx: bool = False) -> str:
+        """
+        Get the checkpoint path based on the 'resume' argument or the latest checkpoint.
+        If this returns a path ending with "checkpoint_0", it means that the checkpoint directory is empty or not found.
+        """
         checkpoint_path = self.checkpoint_path
         if self.multiple_checkpoints:
             num_checkpoints = len(os.listdir(checkpoint_path)) if os.path.exists(checkpoint_path) else 0
             if num_checkpoints > 0:
-                if type(self.resume) is int:
+                if type(self.resume) is int and self.resume != -1 and not ignore_resume_idx:
                     # load the checkpoint at the given index
                     checkpoint_path = os.path.join(checkpoint_path, f"checkpoint_{self.resume}")
                 else:
-                    # load the latest checkpoint
-                    checkpoint_path = os.path.join(checkpoint_path, f"checkpoint_{num_checkpoints}")
+                    # find the latest checkpoint by getting the maximum checkpoint number
+                    latest_checkpoint = max(os.listdir(checkpoint_path), key=lambda x: int(x.split("_")[-1]))
+                    checkpoint_path = os.path.join(checkpoint_path, latest_checkpoint)
             else:
-                raise FileNotFoundError(f"'{checkpoint_path}' checkpoint directory is empty or not found.")
+                # to handle creation afterwards
+                checkpoint_path = os.path.join(checkpoint_path, "checkpoint_0")
 
         return checkpoint_path
 

--- a/src/accmt/trainer.py
+++ b/src/accmt/trainer.py
@@ -1179,6 +1179,7 @@ class Trainer:
 
         loss_tracker_path = os.path.join(checkpoint_path, TRAIN_LOSS_STATE_FILE)
         self.train_loss_state.save(loss_tracker_path)
+        self.state.num_checkpoints_made += 1
         if MASTER_PROCESS:
             training_state_dict = self.state.to_dict()
             training_state_dict["epoch"] = epoch
@@ -1190,6 +1191,7 @@ class Trainer:
             training_state_path = os.path.join(checkpoint_path, STATE_FILE)
             self.state.save(training_state_path, training_state_dict)
             tqdm.write(f"\033[A\033[K{time_prefix()} Checkpoint saved.")
+            self.monitor.log_checkpoint()
 
     def epoch_iterator(self):
         """Epoch iterator handling logic for checkpointing."""

--- a/src/accmt/trainer.py
+++ b/src/accmt/trainer.py
@@ -1156,9 +1156,6 @@ class Trainer:
         self.callback.on_save_checkpoint()
         if MASTER_PROCESS:
             tqdm.write(f"\r{time_prefix()} Saving checkpoint...")
-            import time
-
-            time.sleep(5)
             os.makedirs(self.checkpoint_path, exist_ok=True)
 
         self.accelerator.wait_for_everyone()

--- a/src/tests/legacy/train.py
+++ b/src/tests/legacy/train.py
@@ -100,14 +100,17 @@ if __name__ == "__main__":
         logging_dir=MLFLOW_TRACKING_URI,
         log_with="mlflow",
         log_every=1,
-        monitor=Monitor(grad_norm=True, learning_rate=True),
+        monitor=Monitor(grad_norm=True, learning_rate=True, checkpoint=True),
         compile=False,
         eval_when_start=False,
         metrics=metrics,
         callback=DummyCallback(),
         patience=2,
         disable_model_saving=True,
-        enable_checkpointing=False,
+        enable_checkpointing=True,
+        multiple_checkpoints=True,
+        max_checkpoints=3,
+        # resume=-1,
     )
 
     trainer.log_artifact(".gitignore")


### PR DESCRIPTION
Added support to save multiple checkpoints. This feature can be enabled in Trainer setting the argument 'multiple_checkpoints' to True.

New arguments in Trainer:
- 'multiple_checkpoints'
- 'max_checkpoints'

Arguments modified in Trainer:
- 'resume' can now be an integer value (when 'multiple_checkpoints' is True) to resume from a specific checkpoint in time. Can also be -1 to indicate last checkpoint (resuming from last checkpoint is default).

New state:
- 'num_checkpoints_made'

New arguments in Monitor:
- 'checkpoint', to log checkpoint per step in tracker.