### PR TITLE
Check to only enable tf32 ('high' precision) on cuda capability >= 7

### DIFF
--- a/src/accmt/__init__.py
+++ b/src/accmt/__init__.py
@@ -36,7 +36,9 @@ def allow_tf32(flag=True):
     torch.set_float32_matmul_precision("high" if flag else "highest")
 
 
-allow_tf32()
+if IS_GPU and torch.cuda.is_available() and min(torch.cuda.get_device_capability()) >= 7:
+    # enable tf32 for volta and later
+    allow_tf32()
 
 _init_kwargs = InitProcessGroupKwargs(timeout=timedelta(seconds=86400))
 _dataloader_config = DataLoaderConfiguration(use_seedable_sampler=True)


### PR DESCRIPTION
Enabling "high" precision using CUDA capability < 7 or when using CPU could lead to not desired results, since "high" precision in PyTorch uses a sum of two bf16 numbers or only float32 operations ("highest" precision).