### PR TITLE
Made every datacollator recursive

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ install_requires =
     pympler
     numba
     optuna
-    transformers
 
 [options.packages.find]
 where = src

--- a/src/accmt/__init__.py
+++ b/src/accmt/__init__.py
@@ -18,7 +18,19 @@ import torch
 from accelerate import Accelerator, DataLoaderConfiguration, DistributedType, InitProcessGroupKwargs
 
 from .callbacks import Callback
-from .collate_fns import DataCollatorForLanguageModeling, DataCollatorForLongestSequence, DataCollatorForSeq2Seq
+from .utils import _precision_map, get_seed, is_transformers_available, set_seed
+
+
+if is_transformers_available():
+    from .collate_fns import (
+        DataCollatorForLanguageModeling,
+        DataCollatorForPermutationLanguageModeling,
+        DataCollatorForSeq2Seq,
+        DataCollatorForTokenClassification,
+        DataCollatorForWholeWordMask,
+        DataCollatorWithPadding,
+    )
+
 from .dataloader_samplers import TemperatureSampler
 from .decorators import on_last_process, on_local_main_process, on_local_process, on_main_process, on_process
 from .hp_search import HyperParameterSearch
@@ -28,7 +40,6 @@ from .monitor import Monitor
 from .tqdm import tqdm
 from .trainer import Trainer
 from .utility import IS_CPU, IS_GPU, prepare, prepare_array, prepare_dataframe
-from .utils import _precision_map, get_seed, set_seed
 
 
 def allow_tf32(flag=True):

--- a/src/accmt/collate_fns.py
+++ b/src/accmt/collate_fns.py
@@ -18,117 +18,10 @@ from typing import Any, Optional, Union
 
 import numpy as np
 import torch
+import transformers
 from torch.utils.data._utils.collate import default_collate
-from transformers import PreTrainedModel
+from transformers.data.data_collator import pad_without_fast_tokenizer_warning
 from transformers.tokenization_utils_base import BatchEncoding, PaddingStrategy, PreTrainedTokenizerBase
-
-
-def collate_tokenizer_inputs(batch: list, pad_token_id: int, label_pad_token_id: int, padding_side: str):
-    include_attention_mask = "attention_mask" in batch[0]
-    include_labels = "labels" in batch[0]
-
-    inputs = []
-    labels = []
-    for feature in batch:
-        inputs.append(len(feature["input_ids"]))
-        if include_labels:
-            labels.append(len(feature["labels"]))
-
-    max_input_length = max(inputs)
-    if include_labels:
-        max_label_length = max(labels)
-
-    inputs = []
-    attention_masks = []
-    labels = []
-    for feature in batch:
-        inputs_remainder = [pad_token_id] * (max_input_length - len(feature["input_ids"]))
-        if include_attention_mask:
-            attention_masks_remainder = [0] * (max_input_length - len(feature["input_ids"]))
-        if include_labels:
-            labels_remainder = [label_pad_token_id] * (max_label_length - len(feature["labels"]))
-
-        if include_labels and isinstance(feature["labels"], list):
-            feature = {
-                "input_ids": feature["input_ids"] + inputs_remainder,
-                "attention_mask": (
-                    feature["attention_mask"] + attention_masks_remainder if include_attention_mask else None
-                ),
-                "labels": (feature["labels"] + labels_remainder),
-            }
-        elif padding_side == "right":
-            feature = {
-                "input_ids": np.concatenate([feature["input_ids"], inputs_remainder]).astype(np.int64),
-                "attention_mask": (
-                    np.concatenate([feature["attention_mask"], attention_masks_remainder]).astype(np.int64)
-                    if include_attention_mask
-                    else None
-                ),
-                "labels": (
-                    np.concatenate([feature["labels"], labels_remainder]).astype(np.int64) if include_labels else None
-                ),
-            }
-        else:
-            feature = {
-                "input_ids": np.concatenate([inputs_remainder, feature["input_ids"]]).astype(np.int64),
-                "attention_mask": (
-                    np.concatenate([attention_masks_remainder, feature["attention_mask"]]).astype(np.int64)
-                    if include_attention_mask
-                    else None
-                ),
-                "labels": (
-                    np.concatenate([labels_remainder, feature["labels"]]).astype(np.int64) if include_labels else None
-                ),
-            }
-
-        inputs.append(feature["input_ids"])
-        if include_attention_mask:
-            attention_masks.append(feature["attention_mask"])
-
-        if include_labels:
-            labels.append(feature["labels"])
-
-    output_dict = {"input_ids": torch.from_numpy(np.stack(inputs))}
-
-    if include_attention_mask:
-        output_dict["attention_mask"] = torch.from_numpy(np.stack(attention_masks))
-
-    if include_labels:
-        output_dict["labels"] = torch.from_numpy(np.stack(labels))
-
-    return output_dict
-
-
-# function derived from 'transformers' library: https://github.com/huggingface/transformers/blob/main/src/transformers/data/data_collator.py#L52
-def pad_without_fast_tokenizer_warning(tokenizer, *pad_args, **pad_kwargs):
-    """
-    Pads without triggering the warning about how using the pad function is sub-optimal when using a fast tokenizer.
-    """
-
-    # To avoid errors when using Feature extractors
-    if not hasattr(tokenizer, "deprecation_warnings"):
-        return tokenizer.pad(*pad_args, **pad_kwargs)
-
-    # Save the state of the warning, then disable it
-    warning_state = tokenizer.deprecation_warnings.get("Asking-to-pad-a-fast-tokenizer", False)
-    tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
-
-    try:
-        padded = tokenizer.pad(*pad_args, **pad_kwargs)
-    finally:
-        # Restore the state of the warning.
-        tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = warning_state
-
-    return padded
-
-
-def stack_tensor_dict(tensor_dicts: list[dict[torch.Tensor]]):
-    keys = tensor_dicts[0].keys()
-    return {key: torch.stack([d[key] for d in tensor_dicts]) for key in keys}
-
-
-def stack_iterables(iterables: list[list | tuple]):
-    return torch.stack([torch.tensor(iterable) for iterable in iterables])
 
 
 class BaseDataCollator(ABC):
@@ -162,7 +55,7 @@ class DataCollatorForSeq2Seq(BaseDataCollator):
     """
 
     tokenizer: PreTrainedTokenizerBase
-    model: Optional[PreTrainedModel] = None
+    model: Optional[transformers.PreTrainedModel] = None
     padding: Union[bool, str, PaddingStrategy] = True
     max_length: Optional[int] = None
     pad_to_multiple_of: Optional[int] = None
@@ -249,221 +142,92 @@ class DataCollatorForSeq2Seq(BaseDataCollator):
         return batch
 
 
-class DataCollatorForLongestSequence:
+@dataclass
+class DataCollatorWithPadding(BaseDataCollator, transformers.DataCollatorWithPadding):
     """
-    Automatically adds efficient padding for inputs, while preserving static labels.
-
-    If output of `__getitem__` Dataset logic looks like:
-        `return x, y` (x being a dictionary containing keys `input_ids` and `attention_mask`)
-    then the output of the collator function will be `(x, y)`, `x` being the padded inputs with
-    the same keys and `y` the stacked labels.
-
-    If output of `__getitem__` Dataset logic looks like:
-        `return x` (x being a dictionary containing keys `input_ids` and `attention_mask`)
-    then the output of the collator function will be `x`, being the padded inputs with the same keys.
-
-    NOTE: This collator should be used when labels on your dataset logic are not sequences. If that's the case,
-    see `DataCollatorForSeq2Seq`.
-
-    Args:
-        tokenizer (`Any`):
-            Tokenizer using HuggingFace standard.
+    `DataCollatorWithPadding` from `transformers` library with a recursive approach to handle diverse structures.
+    For documentation, refer to `DataCollatorWithPadding` class
+    (https://huggingface.co/docs/transformers/main_classes/data_collator#transformers.DataCollatorWithPadding).
     """
 
-    def __init__(self, tokenizer: Any, torch_stack: bool = True):
-        self.tokenizer = tokenizer
-        self.pad_token_id = self.tokenizer.pad_token_id
-        self.padding_side = self.tokenizer.padding_side
-        self.torch_stack = torch_stack
-        self.device = None
+    tokenizer: PreTrainedTokenizerBase
+    padding: Union[bool, str, PaddingStrategy] = True
+    max_length: Optional[int] = None
+    pad_to_multiple_of: Optional[int] = None
+    return_tensors: str = "pt"
 
-    def __call__(self, batch: list):
-        inputs = []
-        for feature in batch:
-            # if feature is a tuple, then it would be of type (inputs, targets)
-            if isinstance(feature, tuple):
-                feature = feature[0]  # just take first element
-            inputs.append(len(feature["input_ids"]))
-
-        max_input_length = max(inputs)
-
-        inputs = []
-        attention_masks = []
-        labels = []
-        for feature in batch:
-            if isinstance(feature, tuple):
-                labels.append(feature[1])
-                feature = feature[0]
-            inputs_remainder = [self.pad_token_id] * (max_input_length - len(feature["input_ids"]))
-            attention_masks_remainder = [0] * (max_input_length - len(feature["input_ids"]))
-
-            if self.padding_side == "right":
-                feature = {
-                    "input_ids": np.concatenate([feature["input_ids"], inputs_remainder]).astype(np.int64),
-                    "attention_mask": np.concatenate([feature["attention_mask"], attention_masks_remainder]).astype(
-                        np.int64
-                    ),
-                }
-            else:
-                feature = {
-                    "input_ids": np.concatenate([inputs_remainder, feature["input_ids"]]).astype(np.int64),
-                    "attention_mask": np.concatenate([attention_masks_remainder, feature["attention_mask"]]).astype(
-                        np.int64
-                    ),
-                }
-
-            inputs.append(feature["input_ids"])
-            attention_masks.append(feature["attention_mask"])
-
-        output = {
-            "input_ids": torch.from_numpy(np.stack(inputs)),
-            "attention_mask": torch.from_numpy(np.stack(attention_masks)),
-        }
-
-        if len(labels) > 0:
-            if isinstance(labels[0], dict):
-                keys = labels[0].keys()
-                if self.torch_stack:
-                    out_labels = {k: torch.stack([label[k] for label in labels]) for k in keys}
-                else:
-                    out_labels = {k: [label[k] for label in labels] for k in keys}
-            elif isinstance(labels[0], torch.Tensor):
-                out_labels = labels
-                if self.torch_stack:
-                    out_labels = torch.stack(out_labels)
-            elif isinstance(labels[0], (list, tuple, np.ndarray)):
-                out_labels = [torch.tensor(label, device=self.device) for label in labels]
-                if self.torch_stack:
-                    out_labels = torch.stack(out_labels)
-            else:
-                out_labels = None
-
-            return output, out_labels
-
-        return output
+    def collate_tokenizer_inputs(self, features: list[Union[BatchEncoding, dict]]):
+        return transformers.DataCollatorWithPadding.__call__(self, features)
 
 
-class DataCollatorForLanguageModeling:
+@dataclass
+class DataCollatorForTokenClassification(BaseDataCollator, transformers.DataCollatorForTokenClassification):
     """
-    Collator function to implement automatic language modeling, such as
-    Masked Language Modeling.
-
-    Args:
-        tokenizer (`Any`):
-            Tokenizer using HuggingFace standard.
-        mlm (`bool`, *optional*, defaults to `True`):
-            Implements Masked Language Modeling.
-        mlm_probability (`float`, *optional*, defaults to `0.15`):
-            How much masking is implemented in Masked Language Modeling.
-        ignore_index (`int`, *optional*, defaults to `-100`):
-            Label pad token id. Labels with this value will be ignored in the training process.
-        masked_to_mask (`float`, *optional*, defaults to `0.8`):
-            Probability to replace masked input tokens with mask token. The half remaining percent will
-            replace masked input tokens with random word, and the other half will keep the masked input tokens
-            unchanged. If `apply_random_words` is set to `False`, then the entire remaining percent will be unchanged.
-        apply_random_words (`bool`, *optional*, defaults to `True`):
-            Whether to apply random words during Masked Language Modeling.
-        force_one_output (`bool`, *optional*, defaults to `False`):
-            Whether to force output one output. If Dataset object `__getitem__` function returns a tuple, only the first
-            element will be considered and extra targets will be dropped.
+    `DataCollatorForTokenClassification` from `transformers` library with a recursive approach to handle diverse structures.
+    For documentation, refer to `DataCollatorForTokenClassification` class
+    (https://huggingface.co/docs/transformers/main_classes/data_collator#transformers.DataCollatorForTokenClassification).
     """
 
-    def __init__(
-        self,
-        tokenizer: Any,
-        mlm: bool = True,
-        mlm_probability: float = 0.15,
-        ignore_index: int = -100,
-        masked_to_mask: float = 0.8,
-        apply_random_words: bool = True,
-        force_one_output: bool = False,
-    ) -> Union[dict, tuple[dict, torch.Tensor]]:
-        self.tokenizer = tokenizer
-        self.mlm = mlm
-        self.mlm_probability = mlm_probability
-        self.ignore_index = ignore_index
-        self.masked_to_mask = masked_to_mask
-        self.apply_random_words = apply_random_words
-        self.force_one_output = force_one_output
+    tokenizer: PreTrainedTokenizerBase
+    padding: Union[bool, str, PaddingStrategy] = True
+    max_length: Optional[int] = None
+    pad_to_multiple_of: Optional[int] = None
+    label_pad_token_id: int = -100
+    return_tensors: str = "pt"
 
-    def __call__(self, batch: list) -> dict:
-        has_extra_targets = isinstance(batch[0], (tuple, list))
-        if not has_extra_targets:
-            tokenizer_dict = pad_without_fast_tokenizer_warning(self.tokenizer, batch, return_tensors="pt")
-        else:
-            tokenizer_dict_batch, extra_targets = [], []
-            for elems in batch:
-                tokenizer_dict_batch.append(elems[0])
-                if not self.force_one_output:
-                    extra_targets.append(elems[1:])
+    def collate_tokenizer_inputs(self, features: list[Union[BatchEncoding, dict]]):
+        return transformers.DataCollatorForTokenClassification.__call__(self, features)
 
-            tokenizer_dict = pad_without_fast_tokenizer_warning(
-                self.tokenizer, tokenizer_dict_batch, return_tensors="pt"
-            )
 
-        special_tokens_mask = tokenizer_dict.pop("special_tokens_mask", None)
-        if self.mlm:
-            tokenizer_dict["input_ids"], tokenizer_dict["labels"] = self.torch_mask_tokens(
-                tokenizer_dict["input_ids"], special_tokens_mask=special_tokens_mask
-            )
-        else:
-            labels = tokenizer_dict["input_ids"].clone()
-            if self.tokenizer.pad_token_id is not None:
-                labels[labels == self.tokenizer.pad_token_id] = self.ignore_index
-            tokenizer_dict["labels"] = labels
+@dataclass
+class DataCollatorForLanguageModeling(BaseDataCollator, transformers.DataCollatorForLanguageModeling):
+    """
+    `DataCollatorForLanguageModeling` from `transformers` library with a recursive approach to handle diverse structures.
+    For documentation, refer to `DataCollatorForLanguageModeling` class
+    (https://huggingface.co/docs/transformers/main_classes/data_collator#transformers.DataCollatorForLanguageModeling).
+    """
 
-        if has_extra_targets and not self.force_one_output:
-            num_elems = len(extra_targets[0])
-            extra_targets_return = [[] for _ in range(num_elems)]
+    tokenizer: PreTrainedTokenizerBase
+    mlm: bool = True
+    mlm_probability: float = 0.15
+    pad_to_multiple_of: Optional[int] = None
+    return_tensors: str = "pt"
 
-            for target in extra_targets:
-                for idx in range(num_elems):
-                    tgt = target[idx]
-                    extra_targets_return[idx].append(tgt)
+    def collate_tokenizer_inputs(self, features: list[Union[BatchEncoding, dict]]):
+        return transformers.DataCollatorForLanguageModeling.__call__(self, features)
 
-            stack_funcs = []
-            for idx, extra_target_return in enumerate(extra_targets_return):
-                first_elem = extra_target_return[0]
-                if isinstance(first_elem, torch.Tensor):
-                    stack_funcs.append(torch.stack)
-                elif isinstance(first_elem, dict):
-                    stack_funcs.append(stack_tensor_dict)
-                elif isinstance(first_elem, (tuple, list)):
-                    stack_funcs.append(stack_iterables)
-                else:
-                    stack_funcs.append(torch.tensor)
 
-            extra_targets_return = [
-                stack_funcs[idx](extra_target_return) for idx, extra_target_return in enumerate(extra_targets_return)
-            ]
+@dataclass
+class DataCollatorForWholeWordMask(BaseDataCollator, transformers.DataCollatorForWholeWordMask):
+    """
+    `DataCollatorForWholeWordMask` from `transformers` library with a recursive approach to handle diverse structures.
+    For documentation, refer to `DataCollatorForWholeWordMask` class
+    (https://huggingface.co/docs/transformers/main_classes/data_collator#transformers.DataCollatorForWholeWordMask).
+    """
 
-        if has_extra_targets and not self.force_one_output:
-            return tokenizer_dict, *extra_targets_return
+    tokenizer: PreTrainedTokenizerBase
+    mlm: bool = True
+    mlm_probability: float = 0.15
+    pad_to_multiple_of: Optional[int] = None
+    return_tensors: str = "pt"
 
-        return tokenizer_dict
+    def collate_tokenizer_inputs(self, features: list[Union[BatchEncoding, dict]]):
+        return transformers.DataCollatorForWholeWordMask.__call__(self, features)
 
-    def torch_mask_tokens(self, inputs: torch.Tensor, special_tokens_mask):
-        labels = inputs.clone()
 
-        probability_matrix = torch.full(labels.shape, self.mlm_probability)
-        if special_tokens_mask is None:
-            special_tokens_mask = [
-                self.tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True) for val in labels.tolist()
-            ]
-            special_tokens_mask = torch.tensor(special_tokens_mask, dtype=torch.bool)
-        else:
-            special_tokens_mask = special_tokens_mask.bool()
+class DataCollatorForPermutationLanguageModeling(
+    BaseDataCollator, transformers.DataCollatorForPermutationLanguageModeling
+):
+    """
+    `DataCollatorForPermutationLanguageModeling` from `transformers` library with a recursive approach to handle diverse structures.
+    For documentation, refer to `DataCollatorForPermutationLanguageModeling` class
+    (https://huggingface.co/docs/transformers/main_classes/data_collator#transformers.DataCollatorForPermutationLanguageModeling).
+    """
 
-        probability_matrix.masked_fill_(special_tokens_mask, value=0.0)
-        masked_indices = torch.bernoulli(probability_matrix).bool()
-        labels[~masked_indices] = self.ignore_index
+    tokenizer: PreTrainedTokenizerBase
+    plm_probability: float = 1 / 6
+    max_span_length: int = 5  # maximum length of a span of masked tokens
+    return_tensors: str = "pt"
 
-        indices_replaced = torch.bernoulli(torch.full(labels.shape, self.masked_to_mask)).bool() & masked_indices
-        inputs[indices_replaced] = self.tokenizer.convert_tokens_to_ids(self.tokenizer.mask_token)
-
-        if self.apply_random_words:
-            indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).bool() & masked_indices & ~indices_replaced
-            random_words = torch.randint(len(self.tokenizer), labels.shape, dtype=torch.long)
-            inputs[indices_random] = random_words[indices_random]
-
-        return inputs, labels
+    def collate_tokenizer_inputs(self, features: list[Union[BatchEncoding, dict]]):
+        return transformers.DataCollatorForPermutationLanguageModeling.__call__(self, features)

--- a/src/accmt/hyperparameters.py
+++ b/src/accmt/hyperparameters.py
@@ -18,16 +18,8 @@ from typing import Optional, Union
 import torch
 import yaml
 from torch.optim import lr_scheduler
-from transformers import (
-    Adafactor,
-    get_constant_schedule,
-    get_constant_schedule_with_warmup,
-    get_cosine_schedule_with_warmup,
-    get_cosine_with_hard_restarts_schedule_with_warmup,
-    get_inverse_sqrt_schedule,
-    get_linear_schedule_with_warmup,
-    get_polynomial_decay_schedule_with_warmup,
-)
+
+from .utils import is_transformers_available
 
 
 @dataclass
@@ -37,7 +29,10 @@ class Optimizer:
     Adagrad = torch.optim.Adagrad
     Adamax = torch.optim.Adamax
     AdamW = torch.optim.AdamW
-    Adafactor = Adafactor
+    if is_transformers_available():
+        from transformers import Adafactor
+
+        Adafactor = Adafactor
     ASGD = torch.optim.ASGD
     NAdam = torch.optim.NAdam
     RAdam = torch.optim.RAdam
@@ -56,13 +51,24 @@ class Scheduler:
     CyclicLR = lr_scheduler.CyclicLR
     OneCycleLR = lr_scheduler.OneCycleLR
     CosineAnnealingWarmRestarts = lr_scheduler.CosineAnnealingWarmRestarts
-    CosineWithWarmup = get_cosine_schedule_with_warmup
-    Constant = get_constant_schedule
-    ConstantWithWarmup = get_constant_schedule_with_warmup
-    CosineWithHardRestartsWithWarmup = get_cosine_with_hard_restarts_schedule_with_warmup
-    InverseSQRT = get_inverse_sqrt_schedule
-    LinearWithWarmup = get_linear_schedule_with_warmup
-    PolynomialDecayWithWarmup = get_polynomial_decay_schedule_with_warmup
+    if is_transformers_available():
+        from transformers import (
+            get_constant_schedule,
+            get_constant_schedule_with_warmup,
+            get_cosine_schedule_with_warmup,
+            get_cosine_with_hard_restarts_schedule_with_warmup,
+            get_inverse_sqrt_schedule,
+            get_linear_schedule_with_warmup,
+            get_polynomial_decay_schedule_with_warmup,
+        )
+
+        Constant = get_constant_schedule
+        CosineWithWarmup = get_cosine_schedule_with_warmup
+        ConstantWithWarmup = get_constant_schedule_with_warmup
+        CosineWithHardRestartsWithWarmup = get_cosine_with_hard_restarts_schedule_with_warmup
+        InverseSQRT = get_inverse_sqrt_schedule
+        LinearWithWarmup = get_linear_schedule_with_warmup
+        PolynomialDecayWithWarmup = get_polynomial_decay_schedule_with_warmup
 
 
 class HyperParameters:

--- a/src/accmt/utils.py
+++ b/src/accmt/utils.py
@@ -189,3 +189,12 @@ def print_gpu_users_by_device():
 
     except subprocess.CalledProcessError as e:
         rprint("Error querying GPU usage:", e)
+
+
+def is_transformers_available() -> bool:
+    try:
+        from transformers import __version__  # noqa: F401
+
+        return True
+    except ImportError:
+        return False


### PR DESCRIPTION
Made every DataCollator recursive, related to requirements for v2.0 (#9 ). DataCollators now come directly from `transformers` library (the only exception is `DataCollatorForSeq2Seq`, which has a few optimizations).

If `transformers` is not available and the user tries to import a dependency (such as `Adafactor`, some schedulers or DataCollators) will receive an import error.

`transformers` dependency was removed from `setup.cfg` and internally checks are made with the new utility function `is_transformers_available()`.