### PR TITLE
1.9.2 post fixes

### DIFF
--- a/src/accmt/evaluator.py
+++ b/src/accmt/evaluator.py
@@ -186,6 +186,7 @@ class Evaluator:
         dataset: Dataset,
         eval_logic_fn_name: str = "test_step",
         results_output: Optional[str] = "results.json",
+        verbose: bool = True,
     ):
         """
         Evaluates the model on the given dataset.
@@ -199,6 +200,8 @@ class Evaluator:
                 The name of the method to use for evaluation.
             results_output (`str`, *optional*, defaults to `"results.json"`):
                 The path to the file to save the results to. If `None`, the results will not be saved.
+            verbose (`bool`, *optional*, defaults to `True`):
+                Whether to print the results to the console.
 
         Returns:
             `dict`:
@@ -242,7 +245,7 @@ class Evaluator:
 
         results = self._compute_metrics(loss, dataloader, _loss_implemented)
 
-        if MASTER_PROCESS:
+        if MASTER_PROCESS and verbose:
             print(f"\n\nEvaluation results on dataset with {dataset_length} samples:")
             for k, v in results.items():
                 print(f"\t{k}: {v}")
@@ -257,6 +260,7 @@ class Evaluator:
         module: AcceleratorModule,
         dataset: Dataset,
         results_output: Optional[str] = "results.json",
+        verbose: bool = True,
     ) -> dict[str, Any]:
         """
         Alias for `evaluate` with `eval_logic_fn_name` set to `"test_step"`.
@@ -268,18 +272,21 @@ class Evaluator:
                 The dataset to evaluate on.
             results_output (`str`, *optional*, defaults to `"results.json"`):
                 The path to the file to save the results to. If `None`, the results will not be saved.
+            verbose (`bool`, *optional*, defaults to `True`):
+                Whether to print the results to the console.
 
         Returns:
             `dict`:
                 The results of the evaluation.
         """
-        return self.evaluate(module, dataset, "test_step", results_output)
+        return self.evaluate(module, dataset, "test_step", results_output, verbose)
 
     def evaluate_on_validation(
         self,
         module: AcceleratorModule,
         dataset: Dataset,
         results_output: Optional[str] = "results.json",
+        verbose: bool = True,
     ) -> dict[str, Any]:
         """
         Alias for `evaluate` with `eval_logic_fn_name` set to `"validation_step"`.
@@ -291,12 +298,13 @@ class Evaluator:
                 The dataset to evaluate on.
             results_output (`str`, *optional*, defaults to `"results.json"`):
                 The path to the file to save the results to. If `None`, the results will not be saved.
-
+            verbose (`bool`, *optional*, defaults to `True`):
+                Whether to print the results to the console.
         Returns:
             `dict`:
                 The results of the evaluation.
         """
-        return self.evaluate(module, dataset, "validation_step", results_output)
+        return self.evaluate(module, dataset, "validation_step", results_output, verbose)
 
     def _prepare_batch(self, batch: Any) -> Any:
         """

--- a/src/accmt/evaluator.py
+++ b/src/accmt/evaluator.py
@@ -221,7 +221,7 @@ class Evaluator:
         for batch in tqdm(
             iterable=dataloader,
             total=len(dataloader),
-            desc="📊Evaluating",
+            desc="📊 Evaluating",
             position=0,
             colour="cyan",
             **_tqdm_kwargs,

--- a/src/accmt/trainer.py
+++ b/src/accmt/trainer.py
@@ -1661,6 +1661,7 @@ class Trainer:
         dataset: Dataset,
         eval_logic_fn_name: str = "test_step",
         results_output: Optional[str] = "results.json",
+        verbose: bool = True,
         *,
         metrics: Optional[Union[Metric, list[Metric], dict[Any, Union[Metric, list[Metric]]]]] = None,
         compile: Optional[bool] = None,
@@ -1684,6 +1685,8 @@ class Trainer:
                 The name of the evaluation logic function to use.
             results_output (`str`, *optional*, defaults to `"results.json"`):
                 The path to the file to save the results to.
+            verbose (`bool`, *optional*, defaults to `True`):
+                Whether to print the results to the console.
             metrics (`Metric`, *optional*, defaults to `None`):
                 The metrics to use for evaluation. If `None`, the metrics used in the
                 trainer will be used.
@@ -1740,13 +1743,14 @@ class Trainer:
             prepare_batch=prepare_batch,
             enable_prepare_logging=enable_prepare_logging,
         )
-        return evaluator.evaluate(module, dataset, eval_logic_fn_name, results_output)
+        return evaluator.evaluate(module, dataset, eval_logic_fn_name, results_output, verbose)
 
     def evaluate_on_test(
         self,
         module: AcceleratorModule,
         dataset: Dataset,
         results_output: Optional[str] = "results.json",
+        verbose: bool = True,
         *,
         metrics: Optional[Union[Metric, list[Metric], dict[Any, Union[Metric, list[Metric]]]]] = None,
         compile: Optional[bool] = None,
@@ -1768,6 +1772,8 @@ class Trainer:
                 The dataset to evaluate on.
             results_output (`str`, *optional*, defaults to `"results.json"`):
                 The path to the file to save the results to.
+            verbose (`bool`, *optional*, defaults to `True`):
+                Whether to print the results to the console.
             metrics (`Metric`, *optional*, defaults to `None`):
                 The metrics to use for evaluation. If `None`, the metrics used in the
                 trainer will be used.
@@ -1805,6 +1811,7 @@ class Trainer:
             dataset=dataset,
             eval_logic_fn_name="test_step",
             results_output=results_output,
+            verbose=verbose,
             metrics=metrics,
             compile=compile,
             batch_size=batch_size,
@@ -1821,6 +1828,7 @@ class Trainer:
         module: AcceleratorModule,
         dataset: Dataset,
         results_output: Optional[str] = "results.json",
+        verbose: bool = True,
         *,
         metrics: Optional[Union[Metric, list[Metric], dict[Any, Union[Metric, list[Metric]]]]] = None,
         compile: Optional[bool] = None,
@@ -1842,6 +1850,8 @@ class Trainer:
                 The dataset to evaluate on.
             results_output (`str`, *optional*, defaults to `"results.json"`):
                 The path to the file to save the results to.
+            verbose (`bool`, *optional*, defaults to `True`):
+                Whether to print the results to the console.
             metrics (`Metric`, *optional*, defaults to `None`):
                 The metrics to use for evaluation. If `None`, the metrics used in the
                 trainer will be used.
@@ -1879,6 +1889,7 @@ class Trainer:
             dataset=dataset,
             eval_logic_fn_name="validation_step",
             results_output=results_output,
+            verbose=verbose,
             metrics=metrics,
             compile=compile,
             batch_size=batch_size,


### PR DESCRIPTION
What's changed:
- Added `verbose` argument for evaluate methods (default is `True`).
- Added extra space for 'Evaluating' string in Evaluator for progress bar.
- Fixed TF32 not being enabled sometimes.