### PR TITLE
Fixed dataloader when `batch_size` is None

### DIFF
--- a/src/accmt/trainer.py
+++ b/src/accmt/trainer.py
@@ -1668,8 +1668,8 @@ class Trainer:
                 )
 
         # check if we need uneven batches
-        if any(d.batch_size is None for _, d in train_dataloader) or any(
-            d.batch_size is None for d in val_dataloader.values()
+        if any(d.batch_size is None for _, d in train_dataloader) or (
+            val_dataloader is not None and any(d.batch_size is None for d in val_dataloader.values())
         ):
             self.accelerator.even_batches = False
             if self.accelerator.distributed_type == DistributedType.DEEPSPEED:


### PR DESCRIPTION
DataLoader without `batch_size` cannot run. This PR fixes this issue by applying accelerate`s uneven batches `even_batches=False`. In case of DeepSpeed, in the `deepspeed_config` the `batch_size` argument or `train_micro_batch_size_per_gpu` is necessary, so we default to `1`. This behavior can be modified by accessing a trainer`s property called `_deepspeed_default_micro_batch_size`.